### PR TITLE
Only allow deletion of empty menu sections

### DIFF
--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -2553,7 +2553,7 @@ void GMenu2X::deleteSection() {
 		return;
 	}
 
-	MessageBox mb(this, tr["All links in this section will be removed."] + "\n" + tr["Are you sure?"]);
+	MessageBox mb(this, tr["Really delete this menu section?"] + "\n" + tr[menu->selSection()]);
 	mb.setButton(CONFIRM, tr["Yes"]);
 	mb.setButton(CANCEL,  tr["No"]);
 	if (mb.exec() == CONFIRM) {

--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -2545,6 +2545,14 @@ void GMenu2X::renameSection() {
 }
 
 void GMenu2X::deleteSection() {
+	// only allow deleting of empty section to reduce accidental deletions
+	if ( menu->sectionLinks()->size() > 0) {
+		MessageBox mb(this, tr["Error: cannot delete menu section with links in it."]);
+		mb.setButton(CONFIRM, tr["OK"]);
+		mb.exec();
+		return;
+	}
+
 	MessageBox mb(this, tr["All links in this section will be removed."] + "\n" + tr["Are you sure?"]);
 	mb.setButton(CONFIRM, tr["Yes"]);
 	mb.setButton(CANCEL,  tr["No"]);


### PR DESCRIPTION
This partially addresses https://github.com/MiyooCFW/gmenunx/issues/4 - it prevents the worst-case scenario of accidentally deleting the entire games or emulators menu section. Deleting a section is still possible, but you have to individually delete all of it's links first (or edit from a PC, I suppose...)

Tested on a Powkiddy V90.

I have some other changes in mind, but I'm not sure if I'll get to them today or not. This is safe to merge in as is, though.