### PR TITLE
Github Actions build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       # note: nfriedly/miyoo-toolchain:steward can also be used for an env compatible with miyoo 1.3.3
-      image: nfriedly/miyoo-toolchain:musl
+      image: nfriedly/miyoo-toolchain:latest
     steps:
     - uses: actions/checkout@v2
     - name: build

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -4,10 +4,10 @@ name: CI Build
 on: [push, pull_request]
 
 jobs:   
-  build-gmenunx:
+  build-modern:
+    name: GmenuNX for MiyooCFW 1.4+ (musl libc)
     runs-on: ubuntu-20.04
     container:
-      # note: nfriedly/miyoo-toolchain:steward can also be used for an env compatible with miyoo 1.3.3
       image: nfriedly/miyoo-toolchain:latest
     steps:
     - uses: actions/checkout@v2
@@ -26,5 +26,29 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: GMenuNX Bundle
+        path: dist/miyoo/GMenuNX.zip
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+  build-legacy:
+    name: GMenuNX legacy build for Miyoo 1.3.3 and older (uClibc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:steward
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make -f Makefile.miyoo dist
+    - uses: actions/upload-artifact@v2
+      with:
+        name: GMenuNX legacy binary
+        path: objs/miyoo/gmenu2x
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - uses: actions/upload-artifact@v2
+      with:
+        name: GMenuNX legacy binary (debug)
+        path: objs/miyoo/gmenu2x-debug
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - uses: actions/upload-artifact@v2
+      with:
+        name: GMenuNX legacy Bundle
         path: dist/miyoo/GMenuNX.zip
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,30 @@
+# based on https://github.com/Arcnor/MiyooCFW/blob/ci/.github/workflows/main.yml
+name: CI Build
+
+on: [push, pull_request]
+
+jobs:   
+  build-gmenunx:
+    runs-on: ubuntu-20.04
+    container:
+      # note: nfriedly/miyoo-toolchain:steward can also be used for an env compatible with miyoo 1.3.3
+      image: nfriedly/miyoo-toolchain:musl
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make -f Makefile.miyoo dist
+    - uses: actions/upload-artifact@v2
+      with:
+        name: GMenuNX binary
+        path: objs/miyoo/gmenu2x
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - uses: actions/upload-artifact@v2
+      with:
+        name: GMenuNX binary (debug)
+        path: objs/miyoo/gmenu2x-debug
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - uses: actions/upload-artifact@v2
+      with:
+        name: GMenuNX Bundle
+        path: dist/miyoo/GMenuNX.zip
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`

--- a/src/selector.cpp
+++ b/src/selector.cpp
@@ -288,7 +288,7 @@ void Selector::loadAliases() {
 }
 
 string Selector::getAlias(const string &key, const string &fname) {
-	std::unordered_map<string, string>::iterator i = aliases.find(key);
+	std::tr1::unordered_map<string, string>::iterator i = aliases.find(key);
 	if (i == aliases.end())
 		return fname;
 	else

--- a/src/selector.cpp
+++ b/src/selector.cpp
@@ -288,7 +288,7 @@ void Selector::loadAliases() {
 }
 
 string Selector::getAlias(const string &key, const string &fname) {
-	unordered_map<string, string>::iterator i = aliases.find(key);
+	std::unordered_map<string, string>::iterator i = aliases.find(key);
 	if (i == aliases.end())
 		return fname;
 	else


### PR DESCRIPTION
I ended up putting together my own docker image - https://hub.docker.com/r/nfriedly/miyoo-toolchain (source at  https://github.com/nfriedly/miyoo-toolchain ) and used that to build everything with our musl tooldhain.

I set up my docker image to have both `:musl` and `:steward` tags, but I'm only using the musl one here. We could also build with the steward toolchain if we wanted. (I'm also open to suggestions for better names).

Each build creates archives the full `GMenuNX.zip`, the `gmenu2x` binary, and the `gmenu2x-debug` binary (we should really renames those '2x' binaries to 'nx'). I'm not sure how long archived files hang around in github actions, but I don't think it's forever. 

Still, I think this provides some significant benefits:
1) Validate that PRs can actually build
2) Make it easier to test changes
3) Provide a "known good" environment that anyone can observe and use (the docker image can also be used to compile things locally)
4) Provide a stepping stone towards making everything else build automatically
