### PR TITLE
Fix link to GMenu2X

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GMenuNX
 
-[GMenuNX](https://github.com/pingflood/GMenuNX/) is a fork of [GMenu2X](http://mtorromeo.github.com/gmenu2x) developed to Retrogame RS-97, released under the GNU GPL license v2.
+[GMenuNX](https://github.com/pingflood/GMenuNX/) is a fork of [GMenu2X](http://mtorromeo.github.io/gmenu2x) developed to Retrogame RS-97, released under the GNU GPL license v2.
 
 View releases [changelog](ChangeLog.md).
 


### PR DESCRIPTION
GitHub Pages have moved to github.io instead of github.com. 

See: https://github.blog/2013-04-05-new-github-pages-domain-github-io/ and https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/