### PR TITLE
CI: skip build legacy/steward build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:   
   build-modern:
-    name: GmenuNX for MiyooCFW 1.4+ (musl libc)
+    name: GmenuNX for MiyooCFW (musl libc)
     runs-on: ubuntu-20.04
     container:
       image: nfriedly/miyoo-toolchain:latest
@@ -26,29 +26,5 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: GMenuNX Bundle
-        path: dist/miyoo/GMenuNX.zip
-        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-  build-legacy:
-    name: GMenuNX legacy build for Miyoo 1.3.3 and older (uClibc)
-    runs-on: ubuntu-20.04
-    container:
-      image: nfriedly/miyoo-toolchain:steward
-    steps:
-    - uses: actions/checkout@v2
-    - name: build
-      run: make -f Makefile.miyoo dist
-    - uses: actions/upload-artifact@v2
-      with:
-        name: GMenuNX legacy binary
-        path: objs/miyoo/gmenu2x
-        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-    - uses: actions/upload-artifact@v2
-      with:
-        name: GMenuNX legacy binary (debug)
-        path: objs/miyoo/gmenu2x-debug
-        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-    - uses: actions/upload-artifact@v2
-      with:
-        name: GMenuNX legacy Bundle
         path: dist/miyoo/GMenuNX.zip
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`


### PR DESCRIPTION
It doesn't seem to actually work; it has an error about needing mpeg123.so.o when launched on 1.3.3 (or newer builds)

The musil build, on the other hand, works everywhere - both 1.3.3 and newer builds - so I'm just making it the only build.