### PR TITLE
fix building for pc, add instructions

### DIFF
--- a/Makefile.pc
+++ b/Makefile.pc
@@ -9,7 +9,7 @@ STRIP = strip
 CFLAGS = -I"/usr/include" `sdl-config --cflags` -DTARGET_PC -DTARGET=$(TARGET) -D__BUILDTIME__="$(BUILDTIME)" -DLOG_LEVEL=4 -Wall -Wundef -Wno-deprecated -Wno-unknown-pragmas -Wno-format -pg -O0 -g -ggdb
 CXXFLAGS = $(CFLAGS)
 #LDFLAGS = -L"/usr/lib" `sdl-config --libs` -lfreetype -lSDL_image -lSDL_ttf -lSDL_gfx -ljpeg -lpng12 -lz
-LDFLAGS = -L"/usr/lib" `sdl-config --libs` -lfreetype -lSDL_mixer -lSDL_image -lSDL_ttf -ljpeg -lz
+LDFLAGS = -L"/usr/lib" `sdl-config --libs` -lSDL_image -ljpeg -lpng -lz -lSDL_mixer -lvorbisfile -lvorbis -logg -lSDL_ttf -lfreetype -lSDL -lpthread -lbz2 -lmpg123
 
 OBJDIR = objs/$(TARGET)
 DISTDIR = dist/$(TARGET)/gmenu2x
@@ -29,7 +29,7 @@ dir:
 
 debug: $(OBJS)
 	@echo "Linking gmenu2x-debug..."
-	$(CXX) -o $(APPNAME)-debug $(LDFLAGS) $(OBJS)
+	$(CXX) -o $(APPNAME)-debug $(OBJS) $(LDFLAGS)
 
 shared: debug
 	$(STRIP) $(APPNAME)-debug -o $(APPNAME)
@@ -43,7 +43,7 @@ dist: dir shared
 	install -m755 -d $(DISTDIR)/sections/applications $(DISTDIR)/sections/emulators $(DISTDIR)/sections/games $(DISTDIR)/sections/settings
 	install -m644 -D README.md $(DISTDIR)/README.txt
 	install -m644 -D COPYING $(DISTDIR)/COPYING
-	install -m644 -D ChangeLog $(DISTDIR)/ChangeLog
+	# install -m644 -D ChangeLog $(DISTDIR)/ChangeLog
 	cp -R assets/skins assets/translations $(DISTDIR)
 
 -include $(patsubst src/%.cpp, $(OBJDIR)/src/%.d, $(SOURCES))

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ The fields logged are:
 * BatteryStatus: Computed battery status, from 0 (discharged) to 4 (charged) and 5 (charging);
 * BatteryLevel: Raw battery level as given by system.
 
+## Building for PC
+
+This is primarily useful for development/testing. 
+
+First, install the dependencies. This should work for Debian/Ubuntu systems, use the appropriate package manager for other systems:
+```sh
+sudo apt-get install -y build-essential libsdl-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libboost-all-dev libfreetype6-dev libbz2-dev libmpg123-dev
+```
+
+Compile from the root directory:
+```sh
+make dist -f Makefile.pc
+```
+
+Then run it from the `dist/pc/gmenu2x` directory:
+```sh
+cd dist/pc/gmenu2x/
+./gmenu2x
+```
 
 ## Thanks
 


### PR DESCRIPTION
The makefile changes are basically the same ones I did to the Makefile.miyoo to make it build with the musl toolchain.

I also added instructions to the readme for building it on PC,