### PR TITLE
Fix the default left sectionbar/single-column layout

### DIFF
--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -859,17 +859,25 @@ void GMenu2X::main(bool autoStart,bool bootLogo) {
 				} 
 
 
-				if (i == (uint32_t)menu->selLinkIndex()){
+				bool selected = i == (int)menu->selLinkIndex();
+				if (selected){
 					s->box(ix, iy, linksRect.w, linkHeight, skinConfColors[COLOR_FONT]);
+				}
+
+				if(!confInt["hideIcons"]){
+					sc[menu->sectionLinks()->at(i)->getIconPath()]->blit(s, {ix, iy, 36, linkHeight}, HAlignCenter | VAlignMiddle);
+					hOffset += 32;
+				}
+
+				if (selected) {
 					s->write(titlefont, name, ix + linkSpacing + hOffset, iy + titlefont->getHeight()/2, alignment | VAlignMiddle, skinConfColors[COLOR_BOTTOM_BAR_BG], skinConfColors[COLOR_FONT_OUTLINE]);
 				} else {
 					s->write(titlefont, shortName, ix + linkSpacing + hOffset, iy + titlefont->getHeight()/2, alignment | VAlignMiddle);
 				}
 
-				if(!confInt["hideIcons"]){
-					sc[menu->sectionLinks()->at(i)->getIconPath()]->blit(s, {ix, iy, 36, linkHeight}, HAlignCenter | VAlignMiddle);
-				}
-				if(!confInt["hideDescription"]) {
+				// Warning: this writes on top of the title when menu rows is > 5
+				// todo: restore the bottom bar, and the behavior of showing the description there for a second or two after selecting a link
+				if(selected && !confInt["hideDescription"]) {
 					s->write(font, tr.translate(menu->sectionLinks()->at(i)->getDescription()), ix + linkSpacing + hOffset, iy + linkHeight - linkSpacing/2, alignment | VAlignBottom);
 				}
 
@@ -1560,7 +1568,7 @@ void GMenu2X::readConfig() {
 	evalIntConf( &confInt["sectionBar"], SB_LEFT, 1, 4);
 	evalIntConf( &confInt["textAlignment"], 0,0,1);
 	evalIntConf( &confInt["linkCols"], 1, 1, 8);
-	evalIntConf( &confInt["linkRows"], 6, 1, 18);
+	evalIntConf( &confInt["linkRows"], 5, 1, 18);
 
 	if (!confInt["saveSelection"]) {
 		confInt["section"] = 0;


### PR DESCRIPTION
This fixes two issues: 
* Account for the space the icon takes up when writing the title
* Reduce the default number of rows so that the description isn't on top of the title

Before:
![Screenshot from 2022-03-27 16-24-37](https://user-images.githubusercontent.com/114976/160299545-d0521ab8-74d8-41dc-917c-89f60ed86ec3.png) ![Screenshot from 2022-03-27 16-24-47](https://user-images.githubusercontent.com/114976/160299548-892487e3-b687-4dce-aa55-ec5f9eb21719.png)

After:
![Screenshot from 2022-03-27 16-20-09](https://user-images.githubusercontent.com/114976/160299561-67614978-a678-4a7a-a09c-13a7be181260.png) ![Screenshot from 2022-03-27 16-03-06](https://user-images.githubusercontent.com/114976/160299571-57f05681-6884-4869-bb0d-437d1d37f896.png)

(I worked on top of https://github.com/MiyooCFW/gmenunx/pull/15 to be able to run it on my pc, but this branch does not include those changes.)
